### PR TITLE
Terraform upgrade

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -12,6 +12,59 @@ provider "aws" {
   region  = var.aws_region
 }
 
+resource "aws_vpc" "test_vpc" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "test-vpc"
+  }
+}
+
+resource "aws_subnet" "test_subneta" {
+  vpc_id            = aws_vpc.test_vpc.id
+  cidr_block        = "10.0.0.0/24"
+  availability_zone = "eu-west-2a"
+
+  tags = {
+    Name = "test-subnet"
+  }
+}
+
+resource "aws_subnet" "test_subnetb" {
+  vpc_id            = aws_vpc.test_vpc.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "eu-west-2b"
+
+  tags = {
+    Name = "test-subnet"
+  }
+}
+
+resource "aws_network_interface" "test_interface" {
+  subnet_id   = aws_subnet.test_subneta.id
+
+  tags = {
+    Name = "primary_network_interface"
+  }
+}
+
+resource "aws_internet_gateway" "test_internet_gateway" {
+  vpc_id = aws_vpc.test_vpc.id
+  
+  tags = {
+    Name = "main"
+  }
+}
+
+resource "aws_db_subnet_group" "test_rds_subnet" {
+  name       = "main"
+  subnet_ids = [aws_subnet.test_subneta.id,aws_subnet.test_subnetb.id]
+
+  tags = {
+    Name = "My DB subnet group"
+  }
+}
+
 resource "aws_s3_bucket" "static_website_s3_bucket" {
   bucket = var.s3_bucket_name
   acl    = var.s3_bucket_acl
@@ -40,9 +93,18 @@ resource "aws_instance" "ec2_for_jenkins" {
   ami           = var.image_id
   instance_type = var.ec2_instance_type
   key_name      = var.ec2_key_pair
+  network_interface {
+    network_interface_id = aws_network_interface.test_interface.id
+    device_index         = 0
+  }
   tags = {
     Name = var.ec2_instance_name
   }
+}
+
+resource "aws_eip" "elastic" {
+  instance = aws_instance.ec2_for_jenkins.id
+  vpc      = true
 }
 
 resource "aws_ecr_repository" "app_ecr" {
@@ -59,6 +121,7 @@ resource "aws_db_instance" "il_rds_postgres" {
   name                  = data.aws_ssm_parameter.rds_db_name.value
   username              = data.aws_ssm_parameter.rds_username.value
   password              = data.aws_ssm_parameter.rds_password.value
+  db_subnet_group_name  = aws_db_subnet_group.test_rds_subnet.name
   skip_final_snapshot   = true
-  publicly_accessible   = true
+  publicly_accessible   = false
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -14,6 +14,8 @@ provider "aws" {
 
 resource "aws_vpc" "test_vpc" {
   cidr_block = "10.0.0.0/16"
+  enable_dns_support = true
+  enable_dns_hostnames = true
 
   tags = {
     Name = "test-vpc"
@@ -57,7 +59,7 @@ resource "aws_internet_gateway" "test_internet_gateway" {
 }
 
 resource "aws_db_subnet_group" "test_rds_subnet" {
-  name       = "main"
+  name       = "test-rds-subnet"
   subnet_ids = [aws_subnet.test_subneta.id,aws_subnet.test_subnetb.id]
 
   tags = {
@@ -68,6 +70,7 @@ resource "aws_db_subnet_group" "test_rds_subnet" {
 resource "aws_s3_bucket" "static_website_s3_bucket" {
   bucket = var.s3_bucket_name
   acl    = var.s3_bucket_acl
+  force_destroy = true
   policy = file("policy.json")
   tags = {
     Name = var.s3_bucket_name
@@ -123,5 +126,5 @@ resource "aws_db_instance" "il_rds_postgres" {
   password              = data.aws_ssm_parameter.rds_password.value
   db_subnet_group_name  = aws_db_subnet_group.test_rds_subnet.name
   skip_final_snapshot   = true
-  publicly_accessible   = false
+  publicly_accessible   = true
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -31,7 +31,7 @@ variable "image_id" {
 variable "ec2_instance_type" {
   description = "EC2 free tier instance"
   type        = string
-  default     = "t2.medium"
+  default     = "t2.micro"
 }
 
 variable "ec2_key_pair" {


### PR DESCRIPTION
Add 1 vpc, 2 subnets, network interface, internet gateway, db subnet group. So the infrastructure create it's own network, thus it doesn't depend on the default vpc and subnet structure.